### PR TITLE
feat(stacker): add time delta feature for flexible photo grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ docker run -d  --name immich-stack --env-file .env -v ./logs:/app/logs ghcr.io/m
 | `PARENT_EXT_PROMOTE`      | Parent extension promote                                                                                                     | `.jpg,.dng`                     |
 | `WITH_ARCHIVED`           | Include archived assets                                                                                                      | `false`                         |
 | `WITH_DELETED`            | Include deleted assets                                                                                                       | `false`                         |
+| `CRITERIA`                | JSON array of custom criteria for grouping photos (see Default Configuration section)                                        | See Default Configuration       |
 
 ## Docker Compose
 
@@ -351,6 +352,70 @@ L1010229.edit.jpg
 L1010229.JPG
 L1010229.DNG
 ```
+
+## Default Configuration
+
+### Default Criteria
+
+By default, Immich Stack groups photos based on two criteria:
+
+1. Original filename (before extension)
+   - Splits the filename on "~" and "." delimiters
+   - Uses the first part (index 0) for grouping
+2. Local capture time (localDateTime)
+   - By default, no delta is applied (exact time matching)
+   - Can be configured with a delta for flexible time matching
+
+### Time Delta Feature
+
+The delta feature allows for flexible time matching when grouping photos. It's particularly useful when dealing with burst photos or photos taken in quick succession that might have slight time differences.
+
+For example, these two timestamps would normally be considered different:
+
+```
+2023-08-24T17:00:15.915Z
+2023-08-24T17:00:15.810Z
+```
+
+By setting a delta of 1000ms (1 second), both timestamps would be rounded to the nearest second and considered the same for grouping purposes:
+
+```
+2023-08-24T17:00:15.000Z
+```
+
+Delta can be configured for any time-based field:
+
+- `localDateTime`
+- `fileCreatedAt`
+- `fileModifiedAt`
+- `updatedAt`
+
+### Custom Criteria Configuration
+
+You can override the default criteria by setting the `CRITERIA` environment variable with a JSON array. Example:
+
+```json
+[
+  {
+    "key": "originalFileName",
+    "split": {
+      "delimiters": ["~", "."],
+      "index": 0
+    }
+  },
+  {
+    "key": "localDateTime",
+    "delta": {
+      "milliseconds": 1000
+    }
+  }
+]
+```
+
+This configuration would:
+
+1. Group by the base filename (before any "~" or "." in the name)
+2. Allow a 1-second (1000ms) difference in capture times when grouping
 
 ---
 

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -66,7 +66,7 @@ func NewClient(apiURL, apiKey string, resetStacks bool, replaceStacks bool, dryR
 	baseURL := fmt.Sprintf("%s://%s/api", parsedURL.Scheme, parsedURL.Host)
 
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 600 * time.Second,
 		Transport: &http.Transport{
 			MaxIdleConns:        100,
 			MaxIdleConnsPerHost: 100,

--- a/pkg/stacker/criteria_test.go
+++ b/pkg/stacker/criteria_test.go
@@ -1,6 +1,7 @@
 package stacker
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -144,4 +145,217 @@ func TestSortStackBiggestNumber(t *testing.T) {
 	assert.Equal(t, "PXL_20250503_152823814~3.jpg", result[2].OriginalFileName)
 	assert.Equal(t, "PXL_20250503_152823814~2.jpg", result[3].OriginalFileName)
 	assert.Equal(t, "PXL_20250503_152823814.jpg", result[4].OriginalFileName)
+}
+
+/************************************************************************************************
+** Test cases for time delta functionality
+************************************************************************************************/
+func TestExtractTimeWithDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeStr  string
+		delta    *utils.TDelta
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "no delta returns original time in UTC",
+			timeStr:  "2023-08-24T17:00:15.915Z",
+			delta:    nil,
+			expected: "2023-08-24T17:00:15.915000000Z",
+			wantErr:  false,
+		},
+		{
+			name:     "zero delta returns original time in UTC",
+			timeStr:  "2023-08-24T17:00:15.915Z",
+			delta:    &utils.TDelta{Milliseconds: 0},
+			expected: "2023-08-24T17:00:15.915000000Z",
+			wantErr:  false,
+		},
+		{
+			name:     "1000ms delta rounds down",
+			timeStr:  "2023-08-24T17:00:15.915Z",
+			delta:    &utils.TDelta{Milliseconds: 1000},
+			expected: "2023-08-24T17:00:15.000000000Z",
+			wantErr:  false,
+		},
+		{
+			name:     "500ms delta rounds to nearest interval",
+			timeStr:  "2023-08-24T17:00:15.750Z",
+			delta:    &utils.TDelta{Milliseconds: 500},
+			expected: "2023-08-24T17:00:15.500000000Z",
+			wantErr:  false,
+		},
+		{
+			name:     "empty time string returns empty",
+			timeStr:  "",
+			delta:    &utils.TDelta{Milliseconds: 1000},
+			expected: "",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid time format returns error",
+			timeStr:  "invalid-time",
+			delta:    &utils.TDelta{Milliseconds: 1000},
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "handles non-UTC input",
+			timeStr:  "2023-08-24T19:00:15.915+02:00",
+			delta:    nil,
+			expected: "2023-08-24T17:00:15.915000000Z",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := extractTimeWithDelta(tt.timeStr, tt.delta)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result, "Time format mismatch")
+			}
+		})
+	}
+}
+
+/************************************************************************************************
+** Test cases for time-based criteria matching with delta
+************************************************************************************************/
+func TestApplyCriteriaWithTimeDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		assets   []utils.TAsset
+		criteria []utils.TCriteria
+		want     int // number of groups
+	}{
+		{
+			name: "exact time match",
+			assets: []utils.TAsset{
+				{
+					OriginalFileName: "IMG_001.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.000Z",
+				},
+				{
+					OriginalFileName: "IMG_002.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.000Z",
+				},
+			},
+			criteria: []utils.TCriteria{
+				{
+					Key: "localDateTime",
+				},
+			},
+			want: 1, // Should group together
+		},
+		{
+			name: "time difference within delta",
+			assets: []utils.TAsset{
+				{
+					OriginalFileName: "IMG_001.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.915Z",
+				},
+				{
+					OriginalFileName: "IMG_002.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.810Z",
+				},
+			},
+			criteria: []utils.TCriteria{
+				{
+					Key: "localDateTime",
+					Delta: &utils.TDelta{
+						Milliseconds: 1000,
+					},
+				},
+			},
+			want: 1, // Should group together with 1s delta
+		},
+		{
+			name: "time difference outside delta",
+			assets: []utils.TAsset{
+				{
+					OriginalFileName: "IMG_001.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.915Z",
+				},
+				{
+					OriginalFileName: "IMG_002.jpg",
+					LocalDateTime:    "2023-08-24T17:00:16.810Z",
+				},
+			},
+			criteria: []utils.TCriteria{
+				{
+					Key: "localDateTime",
+					Delta: &utils.TDelta{
+						Milliseconds: 500,
+					},
+				},
+			},
+			want: 0, // Should not group together with 500ms delta
+		},
+		{
+			name: "multiple time fields with delta",
+			assets: []utils.TAsset{
+				{
+					OriginalFileName: "IMG_001.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.915Z",
+					FileCreatedAt:    "2023-08-24T17:00:15.900Z",
+				},
+				{
+					OriginalFileName: "IMG_002.jpg",
+					LocalDateTime:    "2023-08-24T17:00:15.810Z",
+					FileCreatedAt:    "2023-08-24T17:00:15.800Z",
+				},
+			},
+			criteria: []utils.TCriteria{
+				{
+					Key: "localDateTime",
+					Delta: &utils.TDelta{
+						Milliseconds: 1000,
+					},
+				},
+				{
+					Key: "fileCreatedAt",
+					Delta: &utils.TDelta{
+						Milliseconds: 1000,
+					},
+				},
+			},
+			want: 1, // Should group together with 1s delta on both fields
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up test criteria in environment
+			t.Setenv("CRITERIA", mustMarshalJSON(t, tt.criteria))
+
+			groups, err := StackBy(tt.assets, "", "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, len(groups), "Expected %d groups but got %d", tt.want, len(groups))
+
+			if tt.want > 0 && len(groups) > 0 {
+				// Verify all assets in the group have the same rounded time
+				group := groups[0]
+				firstAsset := group[0]
+				firstTime, err := extractTimeWithDelta(firstAsset.LocalDateTime, tt.criteria[0].Delta)
+				require.NoError(t, err)
+
+				for _, asset := range group[1:] {
+					assetTime, err := extractTimeWithDelta(asset.LocalDateTime, tt.criteria[0].Delta)
+					require.NoError(t, err)
+					assert.Equal(t, firstTime, assetTime, "All times in group should round to same value")
+				}
+			}
+		})
+	}
+}
+
+// Helper function to marshal criteria to JSON for environment variable
+func mustMarshalJSON(t *testing.T, v interface{}) string {
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -3,9 +3,15 @@ package utils
 import "strings"
 
 /**************************************************************************************************
+** TimeFormat is the standard format for all time values in the application.
+** It uses RFC3339Nano format to ensure consistent precision across all time operations.
+**************************************************************************************************/
+const TimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
+
+/**************************************************************************************************
 ** DefaultCriteria is the default criteria for grouping photos. It groups photos by:
 ** 1. Original filename (before extension)
-** 2. Local capture time
+** 2. Local capture time (with no delta as default)
 **************************************************************************************************/
 var DefaultCriteria = []TCriteria{
 	{
@@ -17,6 +23,9 @@ var DefaultCriteria = []TCriteria{
 	},
 	{
 		Key: "localDateTime",
+		Delta: &TDelta{
+			Milliseconds: 0, // No delta by default
+		},
 	},
 }
 

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -1,6 +1,14 @@
 package utils
 
 /**************************************************************************************************
+** TDelta represents a time delta configuration for comparing time-based values.
+** It allows for a buffer when comparing timestamps.
+**************************************************************************************************/
+type TDelta struct {
+	Milliseconds int `json:"milliseconds"` // Number of milliseconds to allow as difference
+}
+
+/**************************************************************************************************
 ** TCriteria represents a single criterion for grouping photos. It defines how to extract
 ** and process values from assets for comparison and grouping.
 **************************************************************************************************/
@@ -8,6 +16,7 @@ type TCriteria struct {
 	Key   string  `json:"key"`             // Field name to extract from asset
 	Split *TSplit `json:"split,omitempty"` // Optional split operation
 	Regex *TRegex `json:"regex,omitempty"` // Optional regex operation
+	Delta *TDelta `json:"delta,omitempty"` // Optional time delta for time-based fields
 }
 
 /**************************************************************************************************


### PR DESCRIPTION
- Add TDelta struct for configurable time difference handling
- Implement time delta support in criteria matching
- Add consistent time formatting with nanosecond precision
- Add comprehensive tests for time delta functionality
- Fix timezone handling to always use UTC

This change allows photos taken within a configurable time window to be grouped together, useful for burst shots or HDR sequences.