### PR TITLE
docs(docker): add source repo label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o immich-stack ./cmd/...
 # Use a smaller image for the final container
 FROM alpine:latest
 
+# Apply image labels
+LABEL org.opencontainers.image.source="https://github.com/Majorfi/immich-stack"
+
 WORKDIR /app
 
 # Install bash for the shell script


### PR DESCRIPTION
Added image labels for source tracking.

This helps tracking, filtering, etc. Docker images. And in my specific use case, this will help Renovate link to this repo and find changelogs when it updates my homelab stack.

Thanks!