### PR TITLE
Add hybrid fallback for /stacks 5xx errors

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,53 @@ This guide helps you resolve common issues with Immich Stack.
    WITH_DELETED=false
    ```
 
+### Large Library: 5xx on `GET /stacks`
+
+**Symptoms:**
+
+```
+level=warning msg="⚠️  GET /stacks failed: error response: 500 Internal Server Error - {...}"
+level=warning msg="    A 500 here is typically the JSON.stringify limit on large libraries (Immich issue #15332)."
+level=warning msg="    Falling back to per-asset hybrid lookup. Slower but bypasses the failing endpoint."
+```
+
+**Cause:**
+
+The Immich `GET /stacks` endpoint is unpaginated. On libraries with roughly >100k stacks, the
+JSON response exceeds Node.js's max string length (~512 MB) and the Immich server crashes at
+`JSON.stringify`, returning HTTP 500. See [immich-app/immich#15332](https://github.com/immich-app/immich/issues/15332).
+
+**What the tool does:**
+
+`FetchAllStacks` detects 5xx responses and automatically falls back to a per-asset hybrid
+lookup that bypasses the failing endpoint:
+
+1. Enumerate all asset IDs via paginated `POST /search/metadata`
+2. Phase 1 — parallel `GET /assets/{id}` per asset to read each asset's stack reference
+3. Phase 2 — for assets where Phase 1 reported "no stack" (typically archived primaries that
+   Immich strips from `/assets/{id}` responses), call `GET /stacks?primaryAssetId=X` to
+   recover the missing stack metadata
+
+The result is a stacks map equivalent to what `GET /stacks` would have returned, reconstructed
+from many small HTTP calls instead of one giant one. No user action is required.
+
+**Performance implications:**
+
+- Healthy responses on small/medium libraries are unaffected — `/stacks` is still the primary
+  path (~1 s for ~6k stacks).
+- When the fallback fires, expect on the order of `total_assets / 800` seconds with the default
+  concurrency of 10 in-flight requests. For 450k assets, that's roughly 10 minutes per run.
+- Transient nginx upstream errors (502/503/504) during the fallback are retried automatically.
+  Persistent failures surface as a `PartialResultError` that the caller treats as a soft
+  failure (returns the partial map and continues).
+
+**When to be concerned:**
+
+- A 4xx (401, 403, 404) on `/stacks` is **not** the JSON-limit bug — those propagate as
+  hard errors with no fallback. Check your API key and URL.
+- If the warning fires repeatedly on a small library, the underlying Immich server may be
+  unhealthy for another reason. Check Immich server logs.
+
 ### Grouping Issues
 
 **Symptoms:**
@@ -182,7 +229,6 @@ If you experienced this issue, update to the latest version and verify:
    - If you specify `0000,0001,0002,0003` but have files up to `0999`, they will be sorted correctly at position 999
 
 1. Understanding `sequence:X` behavior:
-
    - `sequence` - Matches any numeric sequence (1, 2, 10, 100, etc.)
    - `sequence:4` - Matches ONLY 4-digit numbers (0001, 0002, not 1, 10, 100)
    - `sequence:IMG_` - Matches only files with IMG\_ prefix followed by numbers
@@ -372,7 +418,6 @@ docker logs -f immich-stack
    - Configuration review
 
 1. **Security**
-
    - Secure API keys
    - Regular updates
    - Access control

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -30,6 +30,22 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("error response: %s - %s", e.Status, e.Body)
 }
 
+/**************************************************************************************************
+** PartialResultError indicates that a result map was returned but some lookups failed along
+** the way. Callers can inspect Phase1Failed / Phase2Failed to decide whether the partial map
+** is acceptable for their use case (e.g., accept if failures < some threshold) or treat the
+** result as fatal. Returned by fetchAllStacksHybrid when at least one underlying call failed
+** but the bulk of the work succeeded.
+**************************************************************************************************/
+type PartialResultError struct {
+	Phase1Failed int
+	Phase2Failed int
+}
+
+func (e *PartialResultError) Error() string {
+	return fmt.Sprintf("partial result: %d phase-1 failures, %d phase-2 failures", e.Phase1Failed, e.Phase2Failed)
+}
+
 // HTTP client configuration constants
 const (
 	defaultHTTPTimeout  = 600 * time.Second
@@ -210,7 +226,11 @@ func (c *Client) FetchAllStacks() (map[string]utils.TStack, error) {
 		c.logger.Warnf("    Falling back to per-asset hybrid lookup. Slower but bypasses the failing endpoint.")
 		hybridMap, hErr := c.fetchAllStacksHybrid(10)
 		if hErr != nil {
-			return nil, fmt.Errorf("error fetching stacks (both /stacks and hybrid fallback failed): /stacks=%w, hybrid=%v", err, hErr)
+			var partial *PartialResultError
+			if !errors.As(hErr, &partial) {
+				return nil, fmt.Errorf("error fetching stacks: both /stacks and hybrid fallback failed: %w", errors.Join(err, hErr))
+			}
+			c.logger.Warnf("    Hybrid fallback returned partial result (%s) — proceeding with what we have", partial)
 		}
 		seen := make(map[string]bool)
 		for _, st := range hybridMap {

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -3,6 +3,7 @@ package immich
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,21 @@ import (
 	"github.com/majorfi/immich-stack/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
+
+/**************************************************************************************************
+** APIError represents a non-2xx response from the Immich API. It preserves the status code
+** for typed inspection (e.g., to detect 5xx for the FetchAllStacks fallback path) while still
+** rendering as the same error string the codebase has historically produced.
+**************************************************************************************************/
+type APIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("error response: %s - %s", e.Status, e.Body)
+}
 
 // HTTP client configuration constants
 const (
@@ -162,7 +178,11 @@ func (c *Client) doRequest(method, path string, body interface{}, result interfa
 		}
 
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("error response: %s - %s", resp.Status, string(body))
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(body),
+		}
 	}
 
 	return fmt.Errorf("failed after %d retries", maxRetries)
@@ -179,7 +199,27 @@ func (c *Client) doRequest(method, path string, body interface{}, result interfa
 func (c *Client) FetchAllStacks() (map[string]utils.TStack, error) {
 	var stacks []utils.TStack
 	if err := c.doRequest(http.MethodGet, "/stacks", nil, &stacks); err != nil {
-		return nil, fmt.Errorf("error fetching stacks: %w", err)
+		if !isLikelyLargeLibrary5xx(err) {
+			return nil, fmt.Errorf("error fetching stacks: %w", err)
+		}
+		c.logger.Warnf("⚠️  GET /stacks failed: %v", err)
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusInternalServerError {
+			c.logger.Warnf("    A 500 here is typically the JSON.stringify limit on large libraries (Immich issue #15332).")
+		}
+		c.logger.Warnf("    Falling back to per-asset hybrid lookup. Slower but bypasses the failing endpoint.")
+		hybridMap, hErr := c.fetchAllStacksHybrid(10)
+		if hErr != nil {
+			return nil, fmt.Errorf("error fetching stacks (both /stacks and hybrid fallback failed): /stacks=%w, hybrid=%v", err, hErr)
+		}
+		seen := make(map[string]bool)
+		for _, st := range hybridMap {
+			if seen[st.ID] {
+				continue
+			}
+			seen[st.ID] = true
+			stacks = append(stacks, st)
+		}
 	}
 
 	// Log info when starting reset stacks operation
@@ -749,4 +789,19 @@ func (c *Client) UpdateAlbum(albumID string, updates map[string]interface{}) err
 	}
 
 	return nil
+}
+
+/**************************************************************************************************
+** isLikelyLargeLibrary5xx returns true when an error from /stacks looks like a server-side
+** 5xx response. On large libraries Immich's GET /stacks endpoint returns 500 because the
+** unpaginated response exceeds Node.js's max string length at JSON.stringify (issue #15332).
+** Any 5xx is treated as a candidate for the hybrid fallback; the fallback path is safe to run
+** even on transient hiccups (it just takes longer than the direct call).
+**************************************************************************************************/
+func isLikelyLargeLibrary5xx(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode >= 500 && apiErr.StatusCode < 600
 }

--- a/pkg/immich/client_fallback_test.go
+++ b/pkg/immich/client_fallback_test.go
@@ -1,0 +1,316 @@
+package immich
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+/**************************************************************************************************
+** pathRouterMockTransport routes responses based on the request URL path and query string.
+** Lets a single test simulate multiple Immich endpoints (e.g., /stacks returns 500 while
+** /search/metadata returns 200 with mock data).
+**************************************************************************************************/
+type pathRouterMockTransport struct {
+	mu      sync.Mutex
+	calls   []string
+	handler func(req *http.Request) (statusCode int, body string)
+}
+
+func (p *pathRouterMockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	target := req.URL.Path
+	if req.URL.RawQuery != "" {
+		target = req.URL.Path + "?" + req.URL.RawQuery
+	}
+	p.mu.Lock()
+	p.calls = append(p.calls, target)
+	p.mu.Unlock()
+
+	statusCode, body := p.handler(req)
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func (p *pathRouterMockTransport) callsSnapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+func newSilentLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	return logger
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksFallbackOn5xx verifies that a 5xx response from /stacks triggers the
+** hybrid fallback path, which then succeeds via /search/metadata + /assets/{id} and produces
+** a correct stacks map.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackOn5xx(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		path := req.URL.Path
+		query := req.URL.RawQuery
+		switch {
+		case path == "/api/stacks" && query == "":
+			return http.StatusInternalServerError, `{"message":"Internal server error"}`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId="):
+			return http.StatusOK, `[]`
+		case path == "/api/search/metadata":
+			return http.StatusOK, `{"assets":{"items":[{"id":"a1"},{"id":"a2"}],"nextPage":""}}`
+		case strings.HasPrefix(path, "/api/assets/"):
+			assetID := strings.TrimPrefix(path, "/api/assets/")
+			return http.StatusOK, fmt.Sprintf(
+				`{"id":"%s","stack":{"id":"s1","primaryAssetId":"a1","assetCount":2}}`,
+				assetID,
+			)
+		}
+		return http.StatusNotFound, `{"error":"no mock for ` + path + `"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	stacksMap, err := client.FetchAllStacks()
+	require.NoError(t, err, "FetchAllStacks should succeed via hybrid fallback")
+	require.NotNil(t, stacksMap)
+
+	assert.Equal(t, "s1", stacksMap["a1"].ID, "asset a1 should resolve to stack s1")
+	assert.Equal(t, "s1", stacksMap["a2"].ID, "asset a2 should resolve to stack s1")
+	assert.Len(t, stacksMap, 2, "map should hold 2 entries (a1, a2)")
+
+	calls := transport.callsSnapshot()
+	hasInitialStacksCall := false
+	hasSearchCall := false
+	for _, c := range calls {
+		if c == "/api/stacks" {
+			hasInitialStacksCall = true
+		}
+		if c == "/api/search/metadata" {
+			hasSearchCall = true
+		}
+	}
+	assert.True(t, hasInitialStacksCall, "initial GET /stacks should be attempted before fallback")
+	assert.True(t, hasSearchCall, "fallback should call /search/metadata")
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksFallbackRecoversArchivedPrimary verifies that an archived primary (whose
+** /assets/{id} response strips the stack field) is recovered via the phase-2
+** /stacks?primaryAssetId fallback.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackRecoversArchivedPrimary(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		path := req.URL.Path
+		query := req.URL.RawQuery
+		switch {
+		case path == "/api/stacks" && query == "":
+			return http.StatusInternalServerError, `{"message":"Internal server error"}`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId=archived-primary"):
+			return http.StatusOK, `[{
+				"id":"s-archived",
+				"primaryAssetId":"archived-primary",
+				"assets":[
+					{"id":"archived-primary"},
+					{"id":"archived-child"}
+				]
+			}]`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId="):
+			return http.StatusOK, `[]`
+		case path == "/api/search/metadata":
+			return http.StatusOK, `{"assets":{"items":[
+				{"id":"normal-a"},
+				{"id":"archived-primary"},
+				{"id":"archived-child"}
+			],"nextPage":""}}`
+		case path == "/api/assets/normal-a":
+			return http.StatusOK, `{"id":"normal-a","stack":null}`
+		case path == "/api/assets/archived-primary":
+			return http.StatusOK, `{"id":"archived-primary","stack":null}`
+		case path == "/api/assets/archived-child":
+			return http.StatusOK, `{"id":"archived-child","stack":null}`
+		}
+		return http.StatusNotFound, `{"error":"no mock for ` + path + `"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	stacksMap, err := client.FetchAllStacks()
+	require.NoError(t, err)
+	require.NotNil(t, stacksMap)
+
+	assert.Equal(t, "s-archived", stacksMap["archived-primary"].ID,
+		"archived primary should be recovered via phase 2 fallback")
+	assert.Equal(t, "s-archived", stacksMap["archived-child"].ID,
+		"archived child should be recovered via phase 2 fallback (from the stack's member list)")
+	_, hasNormalA := stacksMap["normal-a"]
+	assert.False(t, hasNormalA, "normal-a is not in any stack, should not appear in map")
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksFallbackMergesPartialPhase1Stack verifies the phase 2 merge logic when
+** phase 1 has already discovered a stack via a non-archived child. The archived primary's
+** /assets/{id} returns stack=null (the Immich quirk), but phase 2's /stacks?primaryAssetId
+** call returns the full member list — the merge must add the missing primary to the existing
+** stack instead of skipping it.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackMergesPartialPhase1Stack(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		path := req.URL.Path
+		query := req.URL.RawQuery
+		switch {
+		case path == "/api/stacks" && query == "":
+			return http.StatusInternalServerError, `{"message":"Internal server error"}`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId=archived-primary"):
+			return http.StatusOK, `[{
+				"id":"s-mixed",
+				"primaryAssetId":"archived-primary",
+				"assets":[
+					{"id":"archived-primary","isArchived":true,"visibility":"archive"},
+					{"id":"normal-child","isArchived":false,"visibility":"timeline"}
+				]
+			}]`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId="):
+			return http.StatusOK, `[]`
+		case path == "/api/search/metadata":
+			return http.StatusOK, `{"assets":{"items":[
+				{"id":"archived-primary"},
+				{"id":"normal-child"}
+			],"nextPage":""}}`
+		case path == "/api/assets/archived-primary":
+			return http.StatusOK, `{"id":"archived-primary","isArchived":true,"visibility":"archive","stack":null}`
+		case path == "/api/assets/normal-child":
+			return http.StatusOK, `{"id":"normal-child","isArchived":false,"visibility":"timeline","stack":{"id":"s-mixed","primaryAssetId":"archived-primary","assetCount":2}}`
+		}
+		return http.StatusNotFound, `{"error":"no mock for ` + path + `"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	stacksMap, err := client.FetchAllStacks()
+	require.NoError(t, err)
+	require.NotNil(t, stacksMap)
+
+	assert.Equal(t, "s-mixed", stacksMap["normal-child"].ID,
+		"normal child must resolve to s-mixed (phase 1 discovers this)")
+	assert.Equal(t, "s-mixed", stacksMap["archived-primary"].ID,
+		"archived primary must resolve to s-mixed (phase 2 must merge, not skip)")
+	assert.Len(t, stacksMap, 2,
+		"both members of the partially-discovered stack should be in the final map")
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksNoFallbackOn4xx verifies that a 4xx response from /stacks does NOT trigger
+** the fallback — only 5xx responses do (since 4xx indicates client-side problems, not the
+** large-library JSON limit).
+**************************************************************************************************/
+func TestFetchAllStacksNoFallbackOn4xx(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		return http.StatusUnauthorized, `{"message":"Unauthorized"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	_, err := client.FetchAllStacks()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401", "error should mention the 401")
+
+	calls := transport.callsSnapshot()
+	assert.Len(t, calls, 1, "should NOT trigger fallback on 4xx")
+	assert.Equal(t, "/api/stacks", calls[0])
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksFallbackBothFail verifies that when /stacks returns 5xx AND the hybrid
+** fallback also fails, FetchAllStacks returns an error that surfaces both failures.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackBothFail(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		return http.StatusInternalServerError, `{"message":"Internal server error"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	_, err := client.FetchAllStacks()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/stacks", "error should mention initial /stacks failure")
+	assert.Contains(t, err.Error(), "hybrid", "error should mention hybrid fallback failure")
+}
+
+/**************************************************************************************************
+** TestIsLikelyLargeLibrary5xx verifies the predicate that decides whether to trigger the
+** fallback. Only 5xx APIErrors should match; 4xx, plain errors, and nil should not.
+**************************************************************************************************/
+func TestIsLikelyLargeLibrary5xx(t *testing.T) {
+	mkAPIErr := func(code int) error {
+		return &APIError{StatusCode: code, Status: http.StatusText(code), Body: "{}"}
+	}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "500 response", err: mkAPIErr(500), want: true},
+		{name: "502 response", err: mkAPIErr(502), want: true},
+		{name: "503 response", err: mkAPIErr(503), want: true},
+		{name: "504 response", err: mkAPIErr(504), want: true},
+		{name: "599 boundary", err: mkAPIErr(599), want: true},
+		{name: "600 out of range", err: mkAPIErr(600), want: false},
+		{name: "499 just under 5xx", err: mkAPIErr(499), want: false},
+		{name: "401 response", err: mkAPIErr(401), want: false},
+		{name: "404 response", err: mkAPIErr(404), want: false},
+		{name: "wrapped 500", err: fmt.Errorf("ctx: %w", mkAPIErr(500)), want: true},
+		{name: "plain error with '500' in message", err: fmt.Errorf("connection failed with code 500"), want: false},
+		{name: "network error", err: fmt.Errorf("error making request after 3 retries: connection refused"), want: false},
+		{name: "nil error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLikelyLargeLibrary5xx(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/immich/client_fallback_test.go
+++ b/pkg/immich/client_fallback_test.go
@@ -280,6 +280,138 @@ func TestFetchAllStacksFallbackBothFail(t *testing.T) {
 }
 
 /**************************************************************************************************
+** TestFetchAllStacksFallbackPartialResult verifies that when the hybrid path completes with
+** some per-asset failures (e.g., transient 4xx on individual /assets/{id} calls), it returns
+** a PartialResultError. FetchAllStacks then treats that as a soft failure: the partial map
+** is returned to the caller with nil error, since "incomplete map" is strictly better than
+** "no stack info at all" when the primary /stacks endpoint already failed.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackPartialResult(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		path := req.URL.Path
+		query := req.URL.RawQuery
+		switch {
+		case path == "/api/stacks" && query == "":
+			return http.StatusInternalServerError, `{"message":"Internal server error"}`
+		case strings.HasPrefix(path, "/api/stacks") && strings.Contains(query, "primaryAssetId="):
+			return http.StatusOK, `[]`
+		case path == "/api/search/metadata":
+			return http.StatusOK, `{"assets":{"items":[{"id":"a-ok"},{"id":"a-fail"}],"nextPage":""}}`
+		case path == "/api/assets/a-ok":
+			return http.StatusOK, `{"id":"a-ok","stack":{"id":"s1","primaryAssetId":"a-ok","assetCount":1}}`
+		case path == "/api/assets/a-fail":
+			return http.StatusNotFound, `{"error":"asset gone"}`
+		}
+		return http.StatusNotFound, `{"error":"no mock for ` + path + `"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	stacksMap, err := client.FetchAllStacks()
+	require.NoError(t, err, "FetchAllStacks should accept PartialResultError as a soft failure")
+	require.NotNil(t, stacksMap)
+	assert.Equal(t, "s1", stacksMap["a-ok"].ID, "successful asset should be in partial result")
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksHybridReturnsPartialResultError verifies that fetchAllStacksHybrid itself
+** returns a typed *PartialResultError when there are per-asset failures, so callers that don't
+** want partial results can distinguish via errors.As.
+**************************************************************************************************/
+func TestFetchAllStacksHybridReturnsPartialResultError(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		path := req.URL.Path
+		switch {
+		case path == "/api/search/metadata":
+			return http.StatusOK, `{"assets":{"items":[{"id":"a-ok"},{"id":"a-fail"}],"nextPage":""}}`
+		case path == "/api/assets/a-ok":
+			return http.StatusOK, `{"id":"a-ok","stack":null}`
+		case path == "/api/assets/a-fail":
+			return http.StatusNotFound, `{"error":"asset gone"}`
+		case strings.HasPrefix(path, "/api/stacks"):
+			return http.StatusOK, `[]`
+		}
+		return http.StatusNotFound, `{"error":"no mock for ` + path + `"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	_, err := client.fetchAllStacksHybrid(2)
+	require.Error(t, err, "hybrid should report partial failure")
+
+	var partial *PartialResultError
+	require.ErrorAs(t, err, &partial, "error should be inspectable as *PartialResultError")
+	assert.Equal(t, 1, partial.Phase1Failed, "should report exactly 1 phase-1 failure")
+	assert.Equal(t, 0, partial.Phase2Failed, "phase 2 had no failures (no archived primary candidates)")
+}
+
+/**************************************************************************************************
+** TestFetchAllStacksFallbackBothFailErrorsArePreserved verifies that when both /stacks and the
+** hybrid fallback fail with APIErrors, both are reachable via errors.As (thanks to errors.Join
+** preserving the full chain), letting callers inspect the underlying status codes.
+**************************************************************************************************/
+func TestFetchAllStacksFallbackBothFailErrorsArePreserved(t *testing.T) {
+	handler := func(req *http.Request) (int, string) {
+		return http.StatusInternalServerError, `{"message":"Internal server error"}`
+	}
+
+	transport := &pathRouterMockTransport{handler: handler}
+	client := &Client{
+		apiKey: "test",
+		apiURL: "http://test/api",
+		logger: newSilentLogger(),
+		client: &http.Client{Transport: transport},
+	}
+
+	_, err := client.FetchAllStacks()
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr, "an APIError should be reachable via errors.As")
+	assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+}
+
+/**************************************************************************************************
+** TestDoRequestWithUpstreamRetryAttemptsGuard verifies that calling with attempts <= 0 still
+** issues exactly one request (defensive guard against silent no-op success).
+**************************************************************************************************/
+func TestDoRequestWithUpstreamRetryAttemptsGuard(t *testing.T) {
+	for _, attempts := range []int{0, -1, -100} {
+		t.Run(fmt.Sprintf("attempts=%d", attempts), func(t *testing.T) {
+			callCount := 0
+			handler := func(req *http.Request) (int, string) {
+				callCount++
+				return http.StatusOK, `{}`
+			}
+			transport := &pathRouterMockTransport{handler: handler}
+			client := &Client{
+				apiKey: "test",
+				apiURL: "http://test/api",
+				logger: newSilentLogger(),
+				client: &http.Client{Transport: transport},
+			}
+
+			var result struct{}
+			err := client.doRequestWithUpstreamRetry(http.MethodGet, "/probe", nil, &result, attempts)
+			require.NoError(t, err)
+			assert.Equal(t, 1, callCount, "attempts <= 0 must still issue one request")
+		})
+	}
+}
+
+/**************************************************************************************************
 ** TestIsLikelyLargeLibrary5xx verifies the predicate that decides whether to trigger the
 ** fallback. Only 5xx APIErrors should match; 4xx, plain errors, and nil should not.
 **************************************************************************************************/

--- a/pkg/immich/client_hybrid_helpers.go
+++ b/pkg/immich/client_hybrid_helpers.go
@@ -1,0 +1,119 @@
+package immich
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/majorfi/immich-stack/pkg/utils"
+)
+
+/**************************************************************************************************
+** getAssetWithRetry fetches a single asset via GET /assets/{id} with retries on transient
+** upstream errors (502/503/504). Unlike /search/metadata, this endpoint returns the full
+** asset including its stack reference (when applicable).
+**************************************************************************************************/
+func (c *Client) getAssetWithRetry(assetID string, attempts int) (utils.TAsset, error) {
+	var asset utils.TAsset
+	err := c.doRequestWithUpstreamRetry(http.MethodGet, "/assets/"+assetID, nil, &asset, attempts)
+	return asset, err
+}
+
+/**************************************************************************************************
+** getStackByPrimaryWithRetry calls GET /stacks?primaryAssetId=X with retries on transient
+** upstream errors. Returns the stack list (empty if the asset is not a primary).
+**************************************************************************************************/
+func (c *Client) getStackByPrimaryWithRetry(assetID string, attempts int) ([]utils.TStack, error) {
+	var stacks []utils.TStack
+	err := c.doRequestWithUpstreamRetry(http.MethodGet, "/stacks?primaryAssetId="+assetID, nil, &stacks, attempts)
+	return stacks, err
+}
+
+/**************************************************************************************************
+** isTransientUpstreamError returns true for nginx upstream errors (502/503/504) that are
+** typically caused by Immich being slow to respond under load. These are worth retrying.
+** Other errors (4xx, 500, transport errors) propagate immediately.
+**************************************************************************************************/
+func isTransientUpstreamError(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == http.StatusBadGateway ||
+		apiErr.StatusCode == http.StatusServiceUnavailable ||
+		apiErr.StatusCode == http.StatusGatewayTimeout
+}
+
+/**************************************************************************************************
+** doRequestWithUpstreamRetry wraps doRequest with N attempts on transient upstream errors
+** (502/503/504). The base doRequest only retries transport errors, so upstream nginx hiccups
+** under high concurrency would otherwise propagate as hard failures. Used by all hybrid-path
+** callers (per-asset lookup, per-primary lookup, search pagination).
+**************************************************************************************************/
+func (c *Client) doRequestWithUpstreamRetry(method, path string, body interface{}, result interface{}, attempts int) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		err := c.doRequest(method, path, body, result)
+		if err == nil {
+			return nil
+		}
+		if !isTransientUpstreamError(err) {
+			return err
+		}
+		lastErr = err
+		time.Sleep(time.Duration(200*(i+1)) * time.Millisecond)
+	}
+	return lastErr
+}
+
+/**************************************************************************************************
+** fetchAllAssetIDsViaSearch enumerates all asset IDs across all pages of /search/metadata.
+** Older Immich versions ignore withArchived on this endpoint, so we run two separate searches:
+** one default (timeline assets) and one with visibility=archive (archived assets). Results
+** are deduplicated.
+**************************************************************************************************/
+func (c *Client) fetchAllAssetIDsViaSearch() ([]string, error) {
+	seen := make(map[string]bool)
+	var ids []string
+
+	visibilityFilters := []interface{}{nil, "archive"}
+	for _, vis := range visibilityFilters {
+		page := 1
+		const pageSize = 1000
+		for {
+			var response utils.TSearchResponse
+			payload := map[string]interface{}{
+				"size":        pageSize,
+				"page":        page,
+				"order":       "asc",
+				"type":        "IMAGE",
+				"withStacked": true,
+				"withDeleted": true,
+			}
+			if vis != nil {
+				payload["visibility"] = vis
+			}
+			if err := c.doRequestWithUpstreamRetry(http.MethodPost, "/search/metadata", payload, &response, 4); err != nil {
+				return nil, fmt.Errorf("error fetching asset IDs (visibility=%v): %w", vis, err)
+			}
+			for _, asset := range response.Assets.Items {
+				if seen[asset.ID] {
+					continue
+				}
+				seen[asset.ID] = true
+				ids = append(ids, asset.ID)
+			}
+			if response.Assets.NextPage == "" || response.Assets.NextPage == "0" {
+				break
+			}
+			nextPageInt, err := strconv.Atoi(response.Assets.NextPage)
+			if err != nil || nextPageInt == 0 {
+				break
+			}
+			page = nextPageInt
+		}
+	}
+	return ids, nil
+}

--- a/pkg/immich/client_hybrid_helpers.go
+++ b/pkg/immich/client_hybrid_helpers.go
@@ -53,6 +53,9 @@ func isTransientUpstreamError(err error) bool {
 ** callers (per-asset lookup, per-primary lookup, search pagination).
 **************************************************************************************************/
 func (c *Client) doRequestWithUpstreamRetry(method, path string, body interface{}, result interface{}, attempts int) error {
+	if attempts < 1 {
+		attempts = 1
+	}
 	var lastErr error
 	for i := 0; i < attempts; i++ {
 		err := c.doRequest(method, path, body, result)

--- a/pkg/immich/client_hybrid_stacks.go
+++ b/pkg/immich/client_hybrid_stacks.go
@@ -1,0 +1,179 @@
+package immich
+
+import (
+	"sync"
+
+	"github.com/majorfi/immich-stack/pkg/utils"
+)
+
+/**************************************************************************************************
+** fetchAllStacksHybrid combines GET /assets/{id} (Phase 1, fast) with a /stacks?primaryAssetId=X
+** fallback (Phase 2) for assets where Phase 1 returned no stack reference. This is the
+** complete-coverage variant: Phase 1 catches all non-archived stacks fast, Phase 2 recovers
+** archived primaries that /assets/{id} silently strips.
+**
+** Phase 2 only runs for assets reported as "no stack" by Phase 1, so the total cost is
+** roughly N + (N - non-archived stacked count) HTTP calls, where N is the total asset count.
+**
+** @param concurrency - Number of parallel requests in flight. Defaults to 10.
+**************************************************************************************************/
+func (c *Client) fetchAllStacksHybrid(concurrency int) (map[string]utils.TStack, error) {
+	if concurrency <= 0 {
+		concurrency = 10
+	}
+
+	assetIDs, err := c.fetchAllAssetIDsViaSearch()
+	if err != nil {
+		return nil, err
+	}
+	c.logger.Infof("📋 Phase 1: %d assets via /assets/{id} (concurrency=%d)", len(assetIDs), concurrency)
+
+	stacksByID, noStackAssetIDs, p1Failed := c.phase1Lookups(assetIDs, concurrency)
+	c.logger.Infof("📚 Phase 1: %d stacks discovered, %d 'no stack' assets to verify", len(stacksByID), len(noStackAssetIDs))
+
+	c.logger.Infof("📋 Phase 2: %d fallback lookups via /stacks?primaryAssetId", len(noStackAssetIDs))
+	p2Recovered, p2Failed := c.phase2Fallback(noStackAssetIDs, concurrency, stacksByID)
+	c.logger.Infof("📚 Phase 2: %d additional stacks recovered", p2Recovered)
+
+	if p1Failed > 0 || p2Failed > 0 {
+		c.logger.Warnf("⚠️  Failures — phase 1: %d, phase 2: %d", p1Failed, p2Failed)
+	}
+
+	stacksMap := make(map[string]utils.TStack)
+	for _, stack := range stacksByID {
+		for _, asset := range stack.Assets {
+			stacksMap[asset.ID] = *stack
+		}
+	}
+
+	c.logger.Infof("📚 Hybrid total: %d stacks", len(stacksByID))
+	return stacksMap, nil
+}
+
+/**************************************************************************************************
+** phase1Lookups fans out GET /assets/{id} for every asset ID and groups results by stack.
+** Returns the partial stacks map, the list of assets that had no stack reference (candidates
+** for phase 2), and the number of phase-1 failures.
+**************************************************************************************************/
+func (c *Client) phase1Lookups(assetIDs []string, concurrency int) (map[string]*utils.TStack, []string, int) {
+	type result struct {
+		asset utils.TAsset
+		err   error
+	}
+
+	sem := make(chan struct{}, concurrency)
+	results := make(chan result, len(assetIDs))
+	var wg sync.WaitGroup
+
+	for _, id := range assetIDs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(assetID string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			asset, err := c.getAssetWithRetry(assetID, 4)
+			results <- result{asset: asset, err: err}
+		}(id)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	stacksByID := make(map[string]*utils.TStack)
+	var noStack []string
+	failed := 0
+	for r := range results {
+		if r.err != nil {
+			failed++
+			continue
+		}
+		if r.asset.Stack == nil || r.asset.Stack.ID == "" {
+			noStack = append(noStack, r.asset.ID)
+			continue
+		}
+		existing, ok := stacksByID[r.asset.Stack.ID]
+		if !ok {
+			existing = &utils.TStack{
+				ID:             r.asset.Stack.ID,
+				PrimaryAssetID: r.asset.Stack.PrimaryAssetID,
+				Assets:         []utils.TAsset{},
+			}
+			stacksByID[r.asset.Stack.ID] = existing
+		}
+		existing.Assets = append(existing.Assets, r.asset)
+	}
+	return stacksByID, noStack, failed
+}
+
+/**************************************************************************************************
+** phase2Fallback calls /stacks?primaryAssetId=X for every asset whose phase-1 response
+** lacked stack info. Newly discovered stacks (those whose primary is archived) are added
+** to the shared stacksByID map. Stacks already known from phase 1 are skipped.
+**************************************************************************************************/
+func (c *Client) phase2Fallback(assetIDs []string, concurrency int, stacksByID map[string]*utils.TStack) (int, int) {
+	if len(assetIDs) == 0 {
+		return 0, 0
+	}
+
+	type result struct {
+		stacks []utils.TStack
+		err    error
+	}
+
+	sem := make(chan struct{}, concurrency)
+	results := make(chan result, len(assetIDs))
+	var wg sync.WaitGroup
+
+	for _, id := range assetIDs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(assetID string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			stacks, err := c.getStackByPrimaryWithRetry(assetID, 4)
+			results <- result{stacks: stacks, err: err}
+		}(id)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	recovered := 0
+	failed := 0
+	for r := range results {
+		if r.err != nil {
+			failed++
+			continue
+		}
+		for _, stack := range r.stacks {
+			existing, ok := stacksByID[stack.ID]
+			if !ok {
+				stacksByID[stack.ID] = &utils.TStack{
+					ID:             stack.ID,
+					PrimaryAssetID: stack.PrimaryAssetID,
+					Assets:         append([]utils.TAsset{}, stack.Assets...),
+				}
+				recovered++
+				continue
+			}
+			// Stack was already partially discovered in phase 1 (e.g., via a non-archived
+			// child whose /assets/{id} response carried the stack reference). Phase 2's
+			// /stacks response is authoritative, so merge any members phase 1 missed —
+			// typically the archived primary itself, which /assets/{id} hides.
+			seen := make(map[string]bool, len(existing.Assets))
+			for _, a := range existing.Assets {
+				seen[a.ID] = true
+			}
+			for _, a := range stack.Assets {
+				if !seen[a.ID] {
+					existing.Assets = append(existing.Assets, a)
+				}
+			}
+		}
+	}
+	return recovered, failed
+}

--- a/pkg/immich/client_hybrid_stacks.go
+++ b/pkg/immich/client_hybrid_stacks.go
@@ -35,10 +35,6 @@ func (c *Client) fetchAllStacksHybrid(concurrency int) (map[string]utils.TStack,
 	p2Recovered, p2Failed := c.phase2Fallback(noStackAssetIDs, concurrency, stacksByID)
 	c.logger.Infof("📚 Phase 2: %d additional stacks recovered", p2Recovered)
 
-	if p1Failed > 0 || p2Failed > 0 {
-		c.logger.Warnf("⚠️  Failures — phase 1: %d, phase 2: %d", p1Failed, p2Failed)
-	}
-
 	stacksMap := make(map[string]utils.TStack)
 	for _, stack := range stacksByID {
 		for _, asset := range stack.Assets {
@@ -47,6 +43,11 @@ func (c *Client) fetchAllStacksHybrid(concurrency int) (map[string]utils.TStack,
 	}
 
 	c.logger.Infof("📚 Hybrid total: %d stacks", len(stacksByID))
+
+	if p1Failed > 0 || p2Failed > 0 {
+		c.logger.Warnf("⚠️  Failures — phase 1: %d, phase 2: %d", p1Failed, p2Failed)
+		return stacksMap, &PartialResultError{Phase1Failed: p1Failed, Phase2Failed: p2Failed}
+	}
 	return stacksMap, nil
 }
 


### PR DESCRIPTION
## Summary
Implements a hybrid fallback mechanism that activates when the /stacks endpoint returns 5xx errors, enabling the tool to gracefully handle large libraries that may timeout or fail. Includes comprehensive test coverage for fallback behavior and hybrid lookup strategies.

## What changed
- **client.go**: Integrated hybrid fallback logic into stack creation workflow
- **client_hybrid_stacks.go**: New module implementing hybrid lookup strategy when /stacks fails
- **client_hybrid_helpers.go**: Helper functions supporting hybrid asset matching and grouping
- **client_fallback_test.go**: Comprehensive test suite covering fallback activation and hybrid lookup behavior

## Risks
- Hybrid lookup may increase API call count compared to direct /stacks endpoint usage
- Performance characteristics differ between primary and fallback methods; large libraries should be tested
- Fallback logic complexity could obscure issues if error conditions change unexpectedly

## Test plan
1. Run full test suite: `go test ./pkg/immich -v` to verify fallback and hybrid test coverage
2. Test with large libraries (1000+ assets) to verify hybrid fallback activates appropriately
3. Simulate /stacks endpoint 5xx failures and confirm graceful fallback behavior
4. Validate that stacking results are consistent between primary and fallback methods
5. Verify fallback doesn't activate on non-5xx errors

## Docs impact
Update docs to document hybrid fallback behavior, including: when it activates (5xx errors on /stacks), performance implications for large libraries, and any configuration options related to fallback tuning.

## Breaking changes
None