### PR TITLE
Filter partner-shared assets from operations

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,29 @@
+/**************************************************************************************************
+** Shared helpers used by multiple cmd subcommands (stacker, duplicates, fix-trash).
+**************************************************************************************************/
+
+package main
+
+import (
+	"github.com/majorfi/immich-stack/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+/**************************************************************************************************
+** filterOutPartnerAssets removes assets not owned by the current user from a fetched list
+** and logs how many were dropped. Partner-shared assets surfaced by /search/metadata cannot
+** be modified via the Immich stack API (permission denied), so trying to stack them only
+** generates noise — see issue #55.
+**
+** @param assets - Output of FetchAssets
+** @param ownerID - Current user's UUID (from GetCurrentUser)
+** @param logger - For logging the drop count
+** @return []TAsset - Only the assets owned by ownerID
+**************************************************************************************************/
+func filterOutPartnerAssets(assets []utils.TAsset, ownerID string, logger *logrus.Logger) []utils.TAsset {
+	filtered := utils.FilterAssetsByOwner(assets, ownerID)
+	if dropped := len(assets) - len(filtered); dropped > 0 {
+		logger.Infof("⏭️  Skipped %d assets owned by partners (not stackable via API)", dropped)
+	}
+	return filtered
+}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/majorfi/immich-stack/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+func TestFilterOutPartnerAssets(t *testing.T) {
+	me := "11111111-1111-1111-1111-111111111111"
+	partner := "22222222-2222-2222-2222-222222222222"
+	mine := func(id string) utils.TAsset { return utils.TAsset{ID: id, OwnerID: me} }
+	theirs := func(id string) utils.TAsset { return utils.TAsset{ID: id, OwnerID: partner} }
+
+	tests := []struct {
+		name          string
+		assets        []utils.TAsset
+		ownerID       string
+		wantLen       int
+		wantLogSubstr string
+	}{
+		{
+			name:          "drops partner assets and logs the count",
+			assets:        []utils.TAsset{mine("a"), theirs("b"), mine("c"), theirs("d"), theirs("e")},
+			ownerID:       me,
+			wantLen:       2,
+			wantLogSubstr: "Skipped 3 assets owned by partners",
+		},
+		{
+			name:          "no partner assets: no log line emitted",
+			assets:        []utils.TAsset{mine("a"), mine("b")},
+			ownerID:       me,
+			wantLen:       2,
+			wantLogSubstr: "",
+		},
+		{
+			name:          "empty input: no log line emitted",
+			assets:        []utils.TAsset{},
+			ownerID:       me,
+			wantLen:       0,
+			wantLogSubstr: "",
+		},
+		{
+			name:          "empty ownerID is a no-op (defensive default) — no log",
+			assets:        []utils.TAsset{mine("a"), theirs("b")},
+			ownerID:       "",
+			wantLen:       2,
+			wantLogSubstr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := logrus.New()
+			logger.SetOutput(&buf)
+			logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableTimestamp: true})
+
+			got := filterOutPartnerAssets(tt.assets, tt.ownerID, logger)
+			if len(got) != tt.wantLen {
+				t.Errorf("filterOutPartnerAssets returned %d assets, want %d", len(got), tt.wantLen)
+			}
+
+			logOutput := buf.String()
+			if tt.wantLogSubstr == "" {
+				if strings.Contains(logOutput, "Skipped") {
+					t.Errorf("expected no Skipped log, got: %q", logOutput)
+				}
+			} else {
+				if !strings.Contains(logOutput, tt.wantLogSubstr) {
+					t.Errorf("log output %q does not contain %q", logOutput, tt.wantLogSubstr)
+				}
+			}
+		})
+	}
+}

--- a/cmd/duplicates.go
+++ b/cmd/duplicates.go
@@ -74,6 +74,7 @@ func runDuplicates(cmd *cobra.Command, args []string) {
 			logger.Errorf("Error fetching assets: %v", err)
 			continue
 		}
+		assets = filterOutPartnerAssets(assets, user.ID, logger)
 
 		/**********************************************************************************************
 		** List duplicates using the existing function.

--- a/cmd/fixtrash.go
+++ b/cmd/fixtrash.go
@@ -73,6 +73,7 @@ func runFixTrash(cmd *cobra.Command, args []string) {
 			logger.Errorf("Error fetching trashed assets: %v", err)
 			continue
 		}
+		trashedAssets = filterOutPartnerAssets(trashedAssets, user.ID, logger)
 
 		if len(trashedAssets) == 0 {
 			logger.Info("No trashed assets found. Nothing to fix.")
@@ -92,6 +93,7 @@ func runFixTrash(cmd *cobra.Command, args []string) {
 			logger.Errorf("Error fetching all assets: %v", err)
 			continue
 		}
+		allAssets = filterOutPartnerAssets(allAssets, user.ID, logger)
 
 		/**********************************************************************************************
 		** Find assets that should be trashed using reverse criteria matching.

--- a/cmd/stacker.go
+++ b/cmd/stacker.go
@@ -188,7 +188,7 @@ func runStacker(cmd *cobra.Command, args []string) {
 			logger.Infof("Running for user: %s (%s)", user.Name, user.Email)
 			logger.Infof("=====================================================================================")
 			logger.Info("Running in once mode")
-			runStackerOnce(client, logger)
+			runStackerOnce(client, logger, user.ID)
 		}
 	}
 }
@@ -199,8 +199,11 @@ func runStacker(cmd *cobra.Command, args []string) {
 **
 ** @param client - Immich client instance
 ** @param logger - Logger instance for outputting status and errors
+** @param ownerID - Current user's UUID; non-owned assets (e.g., partner-shared with timeline
+**                  visibility) are filtered out before stacking since the API rejects writes
+**                  on them.
 **************************************************************************************************/
-func runStackerOnce(client *immich.Client, logger *logrus.Logger) {
+func runStackerOnce(client *immich.Client, logger *logrus.Logger, ownerID string) {
 	/**********************************************************************************************
 	** Fetch all the assets from Immich.
 	**********************************************************************************************/
@@ -212,6 +215,7 @@ func runStackerOnce(client *immich.Client, logger *logrus.Logger) {
 	if err != nil {
 		logger.Fatalf("Error fetching assets: %v", err)
 	}
+	assets = filterOutPartnerAssets(assets, ownerID, logger)
 
 	/**********************************************************************************************
 	** Group the assets into stacks.
@@ -355,7 +359,7 @@ func runCronLoopForAllUsers(apiKeys []string, apiURL string, logger *logrus.Logg
 			logger.Infof("=====================================================================================")
 			logger.Infof("Running for user: %s (%s)", user.Name, user.Email)
 			logger.Infof("=====================================================================================")
-			runStackerOnce(client, logger)
+			runStackerOnce(client, logger, user.ID)
 		}
 		logger.Infof("Sleeping for %d seconds until next run", cronInterval)
 		time.Sleep(time.Duration(cronInterval) * time.Second)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,6 +98,38 @@ from many small HTTP calls instead of one giant one. No user action is required.
 - If the warning fires repeatedly on a small library, the underlying Immich server may be
   unhealthy for another reason. Check Immich server logs.
 
+### Partner Sharing Assets Skipped
+
+**Symptoms:**
+
+```
+level=info msg="⏭️  Skipped 8755 assets owned by partners (not stackable via API)"
+```
+
+**Cause:**
+
+When a partner has shared their library with you and you have "Show in timeline" enabled
+for that share, Immich's `/search/metadata` endpoint surfaces the partner's assets in your
+timeline. immich-stack used to attempt to stack those assets and get rejected by Immich with
+permission errors (the stack write API requires `AssetUpdate` permission, which you don't
+have on partner-owned assets).
+
+**What the tool does:**
+
+After fetching assets, immich-stack compares `asset.ownerId` against your own user ID (from
+`GET /users/me`) and silently drops anything you don't own. Only owned assets reach the
+stacking pipeline, so no partner-related write attempts ever leave the client. The log line
+above is informational, not an error.
+
+**When to be concerned:**
+
+- A skip count that surprises you may indicate an unexpected partner share — check Immich's
+  Account Settings → Partner Sharing to confirm what's coming in.
+- A skip count of `0` is normal when you have no incoming partner shares or have `Show in
+timeline` disabled.
+
+This resolves [issue #55](https://github.com/Majorfi/immich-stack/issues/55).
+
 ### Grouping Issues
 
 **Symptoms:**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,11 +116,11 @@ have on partner-owned assets).
 
 **What the tool does:**
 
-After fetching assets, immich-stack compares `asset.ownerId` against your own user ID (from
-`GET /users/me`) and filters out anything you don't own before it reaches the stacking
-pipeline. Only owned assets reach the stacking pipeline, so no partner-related write
-attempts ever leave the client. When any assets are filtered out, the skipped count may be
-logged as an informational message, not an error.
+`GET /users/me`) and drops anything you don't own. When any assets are dropped, an info-level
+log line reports the count (see the symptom above). When nothing is dropped — your normal
+case if you have no incoming partner shares — no log line is emitted. Either way, only owned
+assets reach the stacking pipeline, so no partner-related write attempts ever leave the
+client.
 
 **When to be concerned:**
 
@@ -258,7 +258,6 @@ If you experienced this issue, update to the latest version and verify:
    ```
 
 1. Files with numbers beyond your promote list are handled automatically:
-
    - If you specify `0000,0001,0002,0003` but have files up to `0999`, they will be sorted correctly at position 999
 
 1. Understanding `sequence:X` behavior:
@@ -433,19 +432,16 @@ docker logs -f immich-stack
 ## Best Practices
 
 1. **Testing**
-
    - Always use dry run mode first
    - Test with small asset sets
    - Verify criteria before production
 
 1. **Monitoring**
-
    - Enable debug logging
    - Monitor resource usage
    - Check operation results
 
 1. **Maintenance**
-
    - Regular stack cleanup
    - API key rotation
    - Configuration review

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,9 +117,10 @@ have on partner-owned assets).
 **What the tool does:**
 
 After fetching assets, immich-stack compares `asset.ownerId` against your own user ID (from
-`GET /users/me`) and silently drops anything you don't own. Only owned assets reach the
-stacking pipeline, so no partner-related write attempts ever leave the client. The log line
-above is informational, not an error.
+`GET /users/me`) and filters out anything you don't own before it reaches the stacking
+pipeline. Only owned assets reach the stacking pipeline, so no partner-related write
+attempts ever leave the client. When any assets are filtered out, the skipped count may be
+logged as an informational message, not an error.
 
 **When to be concerned:**
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -120,3 +120,30 @@ func BoolToString(b bool) string {
 func GetDir(filePath string) string {
 	return filepath.Dir(filePath)
 }
+
+/**************************************************************************************************
+** FilterAssetsByOwner returns a new slice containing only the assets whose OwnerID matches
+** the given ownerID. Used to exclude partner-shared assets surfaced by /search/metadata when
+** "Show in timeline" is enabled on an incoming partner share: those assets are visible to
+** the current user but cannot be modified via the Immich stack API (permission denied), so
+** including them in stacking attempts wastes API calls and pollutes logs.
+**
+** When ownerID is empty, the input slice is returned unchanged to avoid filtering everything
+** out on a misconfigured caller (defensive default).
+**
+** @param assets - Input assets, typically the output of FetchAssets
+** @param ownerID - The current user's UUID (from GetCurrentUser)
+** @return []TAsset - Only the assets owned by ownerID, preserving input order
+**************************************************************************************************/
+func FilterAssetsByOwner(assets []TAsset, ownerID string) []TAsset {
+	if ownerID == "" {
+		return assets
+	}
+	out := make([]TAsset, 0, len(assets))
+	for _, a := range assets {
+		if a.OwnerID == ownerID {
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -122,18 +122,22 @@ func GetDir(filePath string) string {
 }
 
 /**************************************************************************************************
-** FilterAssetsByOwner returns a new slice containing only the assets whose OwnerID matches
-** the given ownerID. Used to exclude partner-shared assets surfaced by /search/metadata when
-** "Show in timeline" is enabled on an incoming partner share: those assets are visible to
-** the current user but cannot be modified via the Immich stack API (permission denied), so
-** including them in stacking attempts wastes API calls and pollutes logs.
+** FilterAssetsByOwner returns the assets whose OwnerID matches the given ownerID. Used to
+** exclude partner-shared assets surfaced by /search/metadata when "Show in timeline" is
+** enabled on an incoming partner share: those assets are visible to the current user but
+** cannot be modified via the Immich stack API (permission denied), so including them in
+** stacking attempts wastes API calls and pollutes logs.
 **
-** When ownerID is empty, the input slice is returned unchanged to avoid filtering everything
-** out on a misconfigured caller (defensive default).
+** Return-value contract:
+**   - When ownerID is non-empty (the normal case), a NEW slice is returned containing only
+**     the matching assets, in their original order. The input slice is not modified.
+**   - When ownerID is empty (defensive default for misconfigured callers), the input slice
+**     itself is returned unchanged — no copy is made. Callers that intend to mutate the
+**     result must handle this case explicitly.
 **
 ** @param assets - Input assets, typically the output of FetchAssets
 ** @param ownerID - The current user's UUID (from GetCurrentUser)
-** @return []TAsset - Only the assets owned by ownerID, preserving input order
+** @return []TAsset - Either a new filtered slice, or the input slice when ownerID is empty
 **************************************************************************************************/
 func FilterAssetsByOwner(assets []TAsset, ownerID string) []TAsset {
 	if ownerID == "" {

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -283,3 +283,63 @@ func TestGetDir(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterAssetsByOwner(t *testing.T) {
+	me := "11111111-1111-1111-1111-111111111111"
+	partner := "22222222-2222-2222-2222-222222222222"
+	mine := func(id string) TAsset { return TAsset{ID: id, OwnerID: me} }
+	theirs := func(id string) TAsset { return TAsset{ID: id, OwnerID: partner} }
+
+	tests := []struct {
+		name     string
+		assets   []TAsset
+		ownerID  string
+		expected []TAsset
+	}{
+		{
+			name:     "mixed owners drops partner assets and preserves order",
+			assets:   []TAsset{mine("a"), theirs("b"), mine("c"), theirs("d"), mine("e")},
+			ownerID:  me,
+			expected: []TAsset{mine("a"), mine("c"), mine("e")},
+		},
+		{
+			name:     "all owned by current user returns identical slice content",
+			assets:   []TAsset{mine("a"), mine("b"), mine("c")},
+			ownerID:  me,
+			expected: []TAsset{mine("a"), mine("b"), mine("c")},
+		},
+		{
+			name:     "none owned returns empty slice",
+			assets:   []TAsset{theirs("a"), theirs("b")},
+			ownerID:  me,
+			expected: []TAsset{},
+		},
+		{
+			name:     "empty input returns empty slice",
+			assets:   []TAsset{},
+			ownerID:  me,
+			expected: []TAsset{},
+		},
+		{
+			name:     "nil input returns empty slice",
+			assets:   nil,
+			ownerID:  me,
+			expected: []TAsset{},
+		},
+		{
+			name:     "empty ownerID returns input unchanged (defensive default)",
+			assets:   []TAsset{mine("a"), theirs("b")},
+			ownerID:  "",
+			expected: []TAsset{mine("a"), theirs("b")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterAssetsByOwner(tt.assets, tt.ownerID)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("FilterAssetsByOwner = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Excludes partner-shared assets from stacking, duplicate detection, and trash fixing operations. Adds a filtering utility integrated consistently across all commands with test coverage and documentation.

## What changed
- Added `FilterAssetsByOwner` helper in `pkg/utils/helper.go` to filter out non-owned assets
- Added `filterOutPartnerAssets` wrapper in `cmd/common.go` that combines filtering with informational logging, shared by all commands
- Integrated the filter in `cmd/stacker.go`, `cmd/duplicates.go`, and `cmd/fixtrash.go` (the latter filters both `FetchAssets` and `FetchTrashedAssets` outputs)
- Unit tests in `pkg/utils/helper_test.go` (6 sub-tests) and `cmd/common_test.go` (4 sub-tests) covering edge cases and log behavior
- New section in `docs/troubleshooting.md` documenting the skip behavior

## Risks
- Partner-shared assets are excluded from all operations — this matches expected behavior since Immich's stack API rejects writes on non-owned assets anyway
- Users without partner sharing see zero behavior change (filter is a no-op)

## Test plan
- Run unit tests in `common_test.go` and `helper_test.go` to verify filtering logic
- Manual validation with a real Immich instance where Partner Sharing is configured with `inTimeline=true` — confirmed the expected log line and reduced asset count
- Tests pass across all packages (`go test ./...`)

## Docs impact
Updated `docs/troubleshooting.md` with a new "Partner Sharing Assets Skipped" section explaining symptoms, cause, and tool behavior.

Closes #55