### PR TITLE
Add link to docs website to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker logs -f immich-stack
 
 ## Documentation
 
-For detailed documentation, please visit our [documentation](https://github.com/Majorfi/immich-stack/wiki).
+For detailed documentation, please visit the repo's [wiki](https://github.com/Majorfi/immich-stack/wiki) and our [documentation site](https://majorfi.github.io/immich-stack/)
 
 ## Commands
 


### PR DESCRIPTION
Noticed link to docs was pointing to the repo's wiki, which in turn has a link pointing to the documentation website.