### PR TITLE
fix(ci): publish semver Docker tags on automated releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,16 @@ name: Docker Build and Publish
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*.*.*"]
   pull_request:
     branches: ["main"]
+  workflow_call:
+    inputs:
+      version:
+        description: "Semver tag to publish, e.g. v1.2.3. Empty falls back to the git ref."
+        type: string
+        required: false
+        default: ""
   workflow_dispatch:
 
 env:
@@ -55,8 +61,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
             type=sha,format=short
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.create_tag.outputs.new_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +49,13 @@ jobs:
           git config --local user.name "GitHub Action"
           git tag ${{ steps.create_tag.outputs.new_tag }}
           git push origin ${{ steps.create_tag.outputs.new_tag }}
+
+  docker:
+    needs: create-tag
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: ${{ needs.create-tag.outputs.new_tag }}
+    secrets: inherit
 
   goreleaser:
     needs: create-tag


### PR DESCRIPTION
Closes #76

## Root cause

The reported cause (a bad `tags: ["v*.*.*"]` glob) is not the problem — that pattern is valid, and there is exactly one tag-triggered run in the repo's history (`v0.3.0`, 2025-09-12) which was a hand-pushed tag. As @ThibaultNocchi identified in their follow-up comment, the real cause is different.

`release.yml` pushes the release tag using the default `GITHUB_TOKEN`. GitHub deliberately suppresses workflow triggers for pushes made with that token to prevent recursive runs, so `docker-publish.yml`'s tag trigger never fired for an automated release. Across the last 100 `docker-publish.yml` runs, every ref is a branch or a PR — the automated `v0.2.x` tags produced zero runs.

## Fix

`docker-publish.yml` now accepts `workflow_call` with an optional `version` input, and `release.yml` invokes it directly after creating the tag. No new secrets or tokens are required.

`metadata-action`'s `procSemver` resolves the version three ways, which lets a single `value=${{ inputs.version }}` cover every trigger path without duplicated `enable=` guards:

- blank value + non-tag ref → skipped
- blank value + tag ref → falls back to the ref
- non-blank value → overrides the ref

Invalid input only emits `core.warning`, so it can never fail a build.

## Resulting tags

| Trigger | Tags | Change |
| --- | --- | --- |
| push to `main` | `latest`, `main`, **`0.3.1`**, **`0.3`**, `sha-xxxxxxx` | semver tags now published |
| pull request | none (build only, `push: false`) | unchanged |
| manual tag push | `1.0.0`, `1.0`, `sha-xxxxxxx` | unchanged (ref fallback) |
| `workflow_dispatch` | ref-based | unchanged |

## Note on the removed `main` branch trigger

`branches: ["main"]` was dropped from `docker-publish.yml`. `release.yml` already runs on every push to `main`, so keeping both triggers would run two full multi-arch (amd64 + arm64) builds per push, racing to write the same `latest`, `main` and `sha-` tags.

The tradeoff: image publishing now depends on the `create-tag` job succeeding. Restoring that single line brings back an independent `main` build if you would rather keep it as a safety net.

## Verification

- `actionlint` v1.7.12 — exit 0, clean (it validates the caller's `with:` against the callee's declared inputs)
- YAML parses for both workflows
- `semver.valid('v0.3.1')` → `0.3.1`, rendering `{{version}}`=`0.3.1` and `{{major}}.{{minor}}`=`0.3`; `'main'` and `''` → `null` (skipped)

Not verifiable before merge: an actual live run, since the `workflow_call` wiring only exercises once this is on `main`.